### PR TITLE
Add GitHub Actions workflow for lint jobs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,34 @@
+---
+name: lint
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo -H npm install --global \
+              markdownlint-cli
+      - name: markdownlint
+        run: |
+          markdownlint --config .markdownlint.yaml .
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo -H pip install \
+              yamllint
+      - name: yamllint
+        run: |
+          yamllint --config-file .yamllint.yaml .
+...

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,13 @@
+---
+default: true
+
+first-heading-h1: false  # MD002
+line-length:  # MD013
+  tables: false
+blanks-around-lists: false  # MD032
+no-emphasis-as-heading: false  # MD036
+no-space-in-emphasis: false  # MD037
+fenced-code-language: false  # MD040
+first-line-h1: false  # MD041
+reference-links-images: false  # MD052
+...

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+ignore: |
+  unversioned/
+rules:
+  indentation:
+    indent-sequences: consistent


### PR DESCRIPTION
This change comprises a continuous integration (CI) workflow with two jobs: markdownlint, which enforces standards and consistency for Markdown files, and yamllint, which does the same for YAML files.

References:
- markdownlint: https://github.com/DavidAnson/markdownlint
- yamllint: https://github.com/adrienverge/yamllint