### PR TITLE
Add webrick as a dependency

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -39,3 +39,5 @@ gem "kramdown-parser-gfm"
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+gem "webrick", "~> 1.8"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     wdm (0.1.1)
+    webrick (1.8.1)
 
 PLATFORMS
   arm64-darwin-23
@@ -77,6 +78,7 @@ DEPENDENCIES
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.0)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
Jekyll is missing a dependency on WEBrick. Consequently,

    bundle exec jekyll serve

fails with the following error message:

    bundler: failed to load command: jekyll
    .../bundled_gems.rb:74:in `require': cannot load such file -- webrick (LoadError)

(where paths have been elided for readability).

References jekyll/jekyll#8523