### PR TITLE
Use string to access baseurl

### DIFF
--- a/.github/workflows/jekyll.yaml
+++ b/.github/workflows/jekyll.yaml
@@ -29,7 +29,7 @@ jobs:
                       require 'yaml'
 
                       config = YAML.load_file('_config.yaml')
-                      puts config[:baseurl]
+                      puts config['baseurl']
               ")
       - name: archive artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The GitHub Actions workflow for Jekyll parses the baseurl from `_config.yaml` so that the (local) site structure matches what is deployed in production. Unfortunately, commit 699f41e used a symbol rather than a string to access the hash, and using a symbol always returns `nil` -- i.e., a string must be used to retrieve the correct value of the baseurl configuration option.