### PR TITLE
Disable jekyll-titles-from-headings gem

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -15,7 +15,7 @@ gem "minima", "~> 2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages"
+gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -50,4 +50,7 @@ collections:
 
 minima:
   date_format: "%-d %B %Y"
+
+titles_from_headings:
+  enabled: false
 ...


### PR DESCRIPTION
GitHub Pages enables the aforementioned plugin by default, but doing so conflicts with the ability to create pages *without* a title and have those pages omitted from the site's navigation (courtesy of minima's `_includes/header.html`, which ignores pages that do not have a title). Thus, this change disables the jekyll-titles-from-headings plugin.

References: https://github.com/benbalter/jekyll-titles-from-headings