### PR TITLE
Add warning about unmaintained site

### DIFF
--- a/docs/_data/course.yaml
+++ b/docs/_data/course.yaml
@@ -17,4 +17,6 @@ outcomes:
 - Create a course website that uses Jekyll
 - Publish the course website using GitHub Pages
 lms: the Learning Management System (LMS)
+term: current
+deprecated: false
 ...

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,0 +1,30 @@
+<header class="site-header" role="banner">
+
+  <div class="wrapper">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    {%- if page_paths -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          {%- for path in page_paths -%}
+            {%- assign my_page = site.pages | where: "path", path | first -%}
+            {%- if my_page.title -%}
+            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>
+</header>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,3 +1,9 @@
+{% if site.data.course.deprecated %}
+<div class="banner">
+  This site corresponds to the {{ site.data.course.term }} course offering and is no longer maintained.
+</div>
+{% endif %}
+
 <header class="site-header" role="banner">
 
   <div class="wrapper">

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -4,6 +4,8 @@
 // base theme
 @import "{{ site.theme }}";
 
+// additional stylesheets
+@import "admonitions";
 
 // local modifications
 blockquote {
@@ -75,6 +77,16 @@ pre, code {
   font-weight: bolder;
 }
 
+.banner {
+  background: lighten($error, 40%);
+  border: 1px solid rgba($error, 0.5);
+  padding: 0.5em 0.5ex;
+  position: sticky;
+  top: 0;
+  text-align: center;
+  z-index: 1000; // always on top
+}
+
 .estimate {
   color: lighten($text-color, 50%);
   font-size: smaller;
@@ -143,5 +155,3 @@ pre, code {
     padding: 5px 10px;
   }
 }
-
-@import "admonitions";


### PR DESCRIPTION
The websites for multiple course offerings are essentially identical, which makes it difficult to know at a glance the corresponding semester when viewing the site. This change comprises a banner at the top of the site to indicate that the site is for a prior course offering and is no longer maintained.