### PR TITLE
Use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/jekyll.yaml
+++ b/.github/workflows/jekyll.yaml
@@ -32,7 +32,7 @@ jobs:
                       puts config['baseurl']
               ")
       - name: archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: site
           path: |


### PR DESCRIPTION
actions/upload-artifact@v2 was deprecated on 30 June 2024, and GitHub Actions workflows using it are failing with the following error message:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`

Thus, this change updates the version of actions/upload-artifact.