### PR TITLE
Ignore spurious markdownlint warning

### DIFF
--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -19,7 +19,11 @@ assignment metadata (specifically the due "date").
 {% assign lessons = site.collections
     | where: 'label', 'lessons' | first %}
 
-<!-- markdownlint-disable line-length table-column-count table-pipe-style -->
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable blanks-around-tables -->
+<!-- markdownlint-disable line-length -->
+<!-- markdownlint-disable table-column-count -->
+<!-- markdownlint-disable table-pipe-style -->
 
 |    | Lesson | Assignment(s) |
 | -: | :----- | :------------ |
@@ -42,4 +46,4 @@ assignment metadata (specifically the due "date").
 | {{ forloop.index }} | [{{ current.title | default: lesson }}]({{ site.baseurl }}{{ current.url | default: path }}) | {%- for assignment in due -%}[{{ assignment.title }}]({{ site.baseurl }}{{ assignment.url }}){%- endfor -%} |
 {% endfor %}
 
-<!-- markdownlint-enable line-length table-column-count table-pipe-style -->
+<!-- markdownlint-restore -->


### PR DESCRIPTION
This change ignores a spurious markdownlint warning about tables being surrounded by blank lines, a rule introduced in markdownlint 0.35.0.

Due to the number of rules being ignored for the schedule, multiple comments are now used to disable each rule separately, and markdownlint-restore is used to restore the prior configuration.