### PR TITLE
Add script to export Jekyll site

### DIFF
--- a/scripts/export-jekyll-site.sh
+++ b/scripts/export-jekyll-site.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+
+site="http://localhost:4000/jekyll-course-site/"
+output="$1"
+
+
+set -x  # start debugging output
+
+tmp="$(mktemp --directory)"
+
+# TODO: Run jekyll server in background and kill after download
+if ! wget --convert-links --directory-prefix "$tmp" --no-host-directories \
+        --no-verbose --output-file=/tmp/wget.log --recursive \
+        --reject-regex "(.*)\?(.*)" "$site"; then
+  grep --before-context=1 --no-group-separator 'ERROR' /tmp/wget.log \
+      | sed 'N;s/\n/ /'  # join successive lines
+  exit 1
+fi
+
+# convert links (e.g., JavaScript redirects) that aren't handled by wget
+grep --files-with-matches --recursive "$site" "$tmp" \
+        | xargs sed --in-place "s|$site||g"
+
+# wget creates a "clean" export of the site, which updates all the timestamps;
+# only overwrite files whose checksums differ
+rsync -ahPuvz --no-times --checksum --ignore-times "$tmp/" "$output/"
+
+{ set +x; } 2> /dev/null
+echo "Completed export of Jekyll site to $output"


### PR DESCRIPTION
This change comprises a Bash script to automate the creation of a local copy of a Jekyll site. Unfortunately, `jekyll build` uses absolute URLs so `wget` transforms all the links to relative URLs, which is required when viewing the site locally.

Because wget does not convert non-HTML links (such as JavaScript redirects), the host (e.g., http://localhost:4000/) is removed from URLs. This additional rewrite allows redirects to resolve properly when viewing the site from the local file system. In addition, URLs with a query string are *not* included.

Unmodified files are not overwritten in the destination, which allows timestamps to be used to determine which files have been updated.